### PR TITLE
Fix css issue that hid the sponsors in the footer

### DIFF
--- a/components/Footer/Footer.module.css
+++ b/components/Footer/Footer.module.css
@@ -34,10 +34,9 @@
     align-items: center;
 }
 .sponsor img {
-    max-width: 100%;
-    max-height: 100%;
-    width: auto;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
 }
 
 .socials > * {


### PR DESCRIPTION
The css made the sponsor images get a height of 0 in some browsers.