### PR TITLE
Use the enum tier from strapi instead of text field type

### DIFF
--- a/components/page/partners/Sponsor/Sponsor.js
+++ b/components/page/partners/Sponsor/Sponsor.js
@@ -1,13 +1,13 @@
 import { CMS_BASE_URL } from '../../../../common/constants';
 import styles from './Sponsor.module.css';
 
-const Sponsor = ({ title, logo, type, url, description }) => {
+const Sponsor = ({ title, logo, tier, url, description }) => {
   return (
     <div>
-      <a href={url} target="_blank" className={`${styles.sponsor} ${styles[type.toLowerCase()]}`}>
+      <a href={url} target="_blank" className={`${styles.sponsor} ${styles[tier.toLowerCase()]}`}>
         <img className={styles.image} src={CMS_BASE_URL + logo} />
       </a>
-      {type === 'Platinum' ? (
+      {tier === 'Platinum' ? (
         <>
           <h3 className={styles.title}>{title}</h3>
           <h4 className={styles.description}>{description}</h4>

--- a/pages/partners/index.js
+++ b/pages/partners/index.js
@@ -29,7 +29,7 @@ const PartnersPage = ({ sponsors }) => {
         </h2>
         <div className={styles.sponsorList}>
           {sponsors
-            .filter((sponsor) => sponsor.type === 'Platinum')
+            .filter((sponsor) => sponsor.tier === 'Platinum')
             .map((sponsor) => (
               <Sponsor key={sponsor.title} {...sponsor} />
             ))}
@@ -39,7 +39,7 @@ const PartnersPage = ({ sponsors }) => {
         </h2>
         <div className={styles.sponsorList}>
           {sponsors
-            .filter((sponsor) => sponsor.type === 'Gold')
+            .filter((sponsor) => sponsor.tier === 'Gold')
             .map((sponsor) => (
               <Sponsor key={sponsor.title} {...sponsor} />
             ))}
@@ -49,7 +49,7 @@ const PartnersPage = ({ sponsors }) => {
         </h2>
         <div className={styles.sponsorList}>
           {sponsors
-            .filter((sponsor) => sponsor.type === 'Silver')
+            .filter((sponsor) => sponsor.tier === 'Silver')
             .map((sponsor) => (
               <Sponsor key={sponsor.title} {...sponsor} />
             ))}
@@ -59,7 +59,7 @@ const PartnersPage = ({ sponsors }) => {
         </h2>
         <div className={styles.sponsorList}>
           {sponsors
-            .filter((sponsor) => sponsor.type === 'Bronze')
+            .filter((sponsor) => sponsor.tier === 'Bronze')
             .map((sponsor) => (
               <Sponsor key={sponsor.title} {...sponsor} />
             ))}
@@ -97,7 +97,7 @@ PartnersPage.getInitialProps = async function () {
       return {
         title: sponsor.Title,
         logo: sponsor.Logo.url,
-        type: sponsor.Type,
+        tier: sponsor.Tier,
         url: sponsor.Link,
         description: sponsor.Description,
       };


### PR DESCRIPTION
I made a new enum property `tier` in Strapi, to avoid errors caused by misspelling the sponsor tier. 
<img width="1144" alt="Screenshot 2021-11-07 at 16 03 59" src="https://user-images.githubusercontent.com/8343002/140650593-96ae41e4-9afa-41e1-9129-382dac916eaa.png">